### PR TITLE
Update plugin/gnupg.vim

### DIFF
--- a/plugin/gnupg.vim
+++ b/plugin/gnupg.vim
@@ -374,7 +374,7 @@ function s:GPGDecrypt(bufread)
   let filename = expand("<afile>:p")
 
   " clear GPGRecipients and GPGOptions
-  let b:GPGRecipients = g:GPGDefaultRecipients
+  let b:GPGRecipients = copy(g:GPGDefaultRecipients)
   let b:GPGOptions = []
 
   " File doesn't exist yet, so nothing to decrypt


### PR DESCRIPTION
Need to use copy() when setting b:GPGRecipients in GPGDecrypt(), otherwise the local variable will act as a reference to the global one.  The result will be that the global default recipient list will become a super-set of recipients as multiple gpg files are opened.
