### PR TITLE
Do not trigger encrypt on BufWrite etc in settings windows

### DIFF
--- a/plugin/gnupg.vim
+++ b/plugin/gnupg.vim
@@ -170,10 +170,15 @@ augroup GnuPG
                                                 \ " call s:GPGDecrypt(0)"
 
   " convert all text to encrypted text before writing
-  exe "autocmd BufWriteCmd " . g:GPGFilePattern . " call s:GPGBufWritePre()"
-  exe "autocmd BufWriteCmd,FileWriteCmd " . g:GPGFilePattern .
+  " We check for GPGCorrespondingTo to avoid triggering on writes in GPG Options/Recipient windows
+  exe "autocmd BufWriteCmd " . g:GPGFilePattern . " if !exists('b:GPGCorrespondingTo') |" .
+                                                \ " call s:GPGBufWritePre() |" .
+                                                \ " endif"
+
+  exe "autocmd BufWriteCmd,FileWriteCmd " . g:GPGFilePattern . " if !exists('b:GPGCorrespondingTo') |" .
                                                 \ " call s:GPGInit(0) |" .
-                                                \ " call s:GPGEncrypt()"
+                                                \ " call s:GPGEncrypt() |" .
+                                                \ " endif"
 
   " cleanup on leaving vim
   exe "autocmd VimLeave " . g:GPGFilePattern .    " call s:GPGCleanup()"


### PR DESCRIPTION
If a user :w's when in the options or recipient panes the global
bufwrite handlers will be called, triggering an attempt to encrypt the
file. The user will be dropped into the command line recipient adding
process, and the recipients listed in the buffer will be ignored.

This commit checks to see if a buffer is a child of another by looking
for the buffer local var containing the parent buffer name, and only
runs the encryption if it is not present.
