### PR TITLE
Edit recipients when opening a new file

### DIFF
--- a/plugin/gnupg.vim
+++ b/plugin/gnupg.vim
@@ -389,6 +389,13 @@ function s:GPGDecrypt(bufread)
 
   " File doesn't exist yet, so nothing to decrypt
   if empty(glob(filename))
+
+    " This is a new file, so force the user to edit the recipient list if
+    " they open a new file and public keys are preferred
+    if (exists("g:GPGPreferSymmetric") && g:GPGPreferSymmetric == 0)
+        call s:GPGEditRecipients()
+    endif
+
     return
   endif
 


### PR DESCRIPTION
The previous behaviour of this plugin was to open the recipient pane
immediately after opening a new file with the correct extension. The
documentation states that this should still occur, so this commit
implements the behaviour in a slightly different manner than the old
plugin.
