### PR TITLE
Fixes a problem that made vim-gnupg open an emtpy file instead of

### DIFF
--- a/plugin/gnupg.vim
+++ b/plugin/gnupg.vim
@@ -404,7 +404,7 @@ function s:GPGDecrypt(bufread)
   let b:GPGOptions = []
 
   " File doesn't exist yet, so nothing to decrypt
-  if empty(glob(filename))
+  if !filereadable(filename)
     " Allow the user to define actions for GnuPG buffers
     silent doautocmd User GnuPG
     " call the autocommand for the file minus .gpg$


### PR DESCRIPTION
decrypting the existing one if the filename or path contains pairs
of square brackets

vim-gnupg uses `glob` to check if a file exists but glob expands wildcards (including  [ and ]) so, the check returns 'false' even if the file exists if the filename or path is something like `[0]-Directory/File`.

Using `filereadable` avoids this problem.
