### PR TITLE
change decrypt behavior to set armor option if filename ends with .asc

### DIFF
--- a/plugin/gnupg.vim
+++ b/plugin/gnupg.vim
@@ -520,8 +520,9 @@ function s:GPGDecrypt(bufread)
     call s:GPGDebug(2, 'called FileReadPre autocommand for ' . fnameescape(expand('<afile>:r')))
   endif
 
-  " check if the message is armored
-  if (match(output, "gpg: armor header") >= 0)
+  " check if the message is armored or if filename ends with .asc
+  if (match(output, "gpg: armor header") >= 0 || expand('<afile>') =~ '\.asc$')
+
     call s:GPGDebug(1, "this file is armored")
     let b:GPGOptions += ["armor"]
   endif


### PR DESCRIPTION
changes default behaviour slightly so that decrypt sets the option to save with armor either if the file was previously encoded with armor (and the users version of gpg correctly reports it) or if the filename ends with the .asc extension.