### PR TITLE
Add vim help documentation

### DIFF
--- a/doc/gnupg.txt
+++ b/doc/gnupg.txt
@@ -1,0 +1,165 @@
+*gnupg.txt* transparent editing of gpg encrypted files
+
+                                67 6E 75 70 67 
+
+CONTENTS                                                         *gnupg-contents*
+
+  1. Installation ...................... |gnupg-installation|
+  2. Commands .......................... |gnupg-commands|
+  3. Variables ......................... |gnupg-variables|
+  4. Known Issues ...................... |gnupg-knownissues|
+  5. Credits ........................... |gnupg-credits|
+  6. License ........................... |gnupg-license|
+
+INSTALLATION                                                 *gnupg-installation*
+
+Copy the gnupg.vim file to the $HOME/.vim/plugin directory.  Refer to
+':help add-plugin', ':help add-global-plugin' and ':help runtimepath' for more
+details about Vim plugins.
+
+From "man 1 gpg-agent":
+
+...
+You should always add the following lines to your .bashrc or whatever
+initialization file is used for all shell invocations:
+
+     GPG_TTY=`tty`
+     export GPG_TTY
+
+It is important that this environment variable always reflects the out‐
+put of the tty command. For W32 systems this option is not required.
+...
+
+Most distributions provide software to ease handling of gpg and gpg-agent.
+Examples are keychain or seahorse.
+
+If there are specific actions that should take place when editing a
+GnuPG-managed buffer, an autocmd for the User event and GnuPG pattern can
+be defined.  For example, the following will set 'textwidth' to 72 for all
+GnuPG-encrypted buffers:
+
+    autocmd User GnuPG setl textwidth=72
+
+This will be triggered before any BufRead or BufNewFile autocmds, and
+therefore will not take precedence over settings specific to any filetype
+that may get set.
+
+COMMANDS                                                         *gnupg-commands*
+
+                                                              *GPGEditRecipients*
+:GPGEditRecipients                  Opens a scratch buffer to change the list of
+                                    recipients. Recipients that are unknown (not
+                                    in your public key) are highlighted and have
+                                    a prepended "!". Closing the buffer makes
+                                    the changes permanent.
+
+                                                              *GPGViewRecipients*
+:GPGViewRecipients                  Prints the list of recipients.
+
+                                                                 *GPGEditOptions*
+:GPGEditOptions                     Opens a scratch buffer to change the
+                                    options for encryption (symmetric,
+                                    asymmetric, signing). Closing the buffer
+                                    makes the changes permanent.
+
+                                    WARNING: There is no check of the entered
+                                    options, so you need to know what you are
+                                    doing.
+
+                                                                 *GPGViewOptions*
+:GPGViewOptions                     Prints the list of options.
+
+VARIABLES                                                       *gnupg-variables*
+
+                                                                  *GPGExecutable*
+  If set used as gpg executable, otherwise the system chooses what is run
+  when "gpg" is called. Defaults to "gpg --trust-model always".
+
+                                                                    *GPGUseAgent*
+  If set to 0 a possible available gpg-agent won't be used. Defaults to 1.
+
+                                                             *GPGPreferSymmetric*
+  If set to 1 symmetric encryption is preferred for new files. Defaults to 0.
+
+                                                                 *GPGPreferArmor*
+  If set to 1 armored data is preferred for new files. Defaults to 0
+  unless a "*.asc" file is being edited.
+
+                                                                  *GPGPreferSign*
+  If set to 1 signed data is preferred for new files. Defaults to 0.
+
+                                                           *GPGDefaultRecipients*
+  If set, these recipients are used as defaults when no other recipient is
+  defined. This variable is a Vim list. Default is unset.
+
+                                                          *GPGPossibleRecipients*
+  If set, these contents are loaded into the recipients dialog. This
+  allows to add commented lines with possible recipients to the list,
+  which can be uncommented to select the actual recipients. Default is
+  unset. Example:
+
+    let g:GPGPossibleRecipients=[
+      \"Example User <example@example.com>",
+      \"Other User <otherexample@example.com>"
+    \]
+
+
+                                                                    *GPGUsePipes*
+  If set to 1, use pipes instead of temporary files when interacting with
+  gnupg.  When set to 1, this can cause terminal-based gpg agents to not
+  display correctly when prompting for passwords.  Defaults to 0.
+
+                                                                     *GPGHomedir*
+If set, specifies the directory that will be used for GPG's homedir. This
+corresponds to gpg's --homedir option.  This variable is a Vim
+string. Default is unset.
+
+                                                                 *GPGFilePattern*
+If set, overrides the default set of file patterns that determine whether this
+plugin will be activated. Defaults to '*.\(gpg\|asc\|pgp\)'.
+
+KNOWN ISSUES                                                 *gnupg-knownissues*
+
+In some cases gvim can't decrypt files
+
+This is caused by the fact that a running gvim has no TTY and thus gpg is
+not able to ask for the passphrase by itself. This is a problem for Windows
+and Linux versions of gvim and could not be solved unless a "terminal
+emulation" is implemented for gvim. To circumvent this you have to use any
+combination of gpg-agent and a graphical pinentry program:
+
+  - gpg-agent only:
+      you need to provide the passphrase for the needed key to gpg-agent
+      in a terminal before you open files with gvim which require this key.
+
+  - pinentry only:
+      you will get a popup window every time you open a file that needs to
+      be decrypted.
+
+  - gpgagent and pinentry:
+      you will get a popup window the first time you open a file that
+      needs to be decrypted.
+
+CREDITS                                                          *gnupg-credits*
+
+- Mathieu Clabaut for inspirations through his vimspell.vim script.
+- Richard Bronosky for patch to enable ".pgp" suffix.
+- Erik Remmelzwaal for patch to enable windows support and patient beta
+  testing.
+- Lars Becker for patch to make gpg2 working.
+- Thomas Arendsen Hein for patch to convert encoding of gpg output.
+- Karl-Heinz Ruskowski for patch to fix unknown recipients and trust model
+  and patient beta testing.
+- Giel van Schijndel for patch to get GPG_TTY dynamically.
+- Sebastian Luettich for patch to fix issue with symmetric encryption an set
+  recipients.
+- Tim Swast for patch to generate signed files.
+- James Vega for patches for better '*.asc' handling, better filename
+  escaping and better handling of multiple keyrings.
+
+LICENSE                                                           *gnupg-license*
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version. See http://www.gnu.org/copyleft/gpl-2.0.txt


### PR DESCRIPTION
I figure, based on https://github.com/jamessan/vim-gnupg/pull/13, that this might be a long shot, but I'm trying anyway. I'm integrating `vim-gnupg` into a particular aspect of my workflow and I am needing to look at the documentation often. This is made difficult by the fact that `vim-gnupg` does not have traditional documentation.

All I've done here is make a `doc/gnupg.txt` file that contains the same information as the Documentation section of the file `plugin/gnpug.vim`, only organized as a vim help document.
