### PR TITLE
Added a newline after the scratch buffer comment

### DIFF
--- a/plugin/gnupg.vim
+++ b/plugin/gnupg.vim
@@ -847,6 +847,7 @@ function s:GPGEditRecipients()
     silent put ='GPG: Data after recipients between and including \"(\" and \")\" is ignored.'
     silent put ='GPG: Closing this buffer commits changes.'
     silent put ='GPG: ----------------------------------------------------------------------'
+    silent put =''
 
     " get the recipients
     let recipients = s:GPGCheckRecipients(getbufvar(b:GPGCorrespondingTo, "GPGRecipients"))


### PR DESCRIPTION
Hi,
First of all thanks for your hard work @jamessan this vim plugin is not only very useful but also awesome.

As for the change I propose, it's a very simple one. As I was using vim I constantly clicked "i" to edit the recipient scratch buffer, then of course I had to press ESC and "o" to create a newline after the scratch comment and then insert my recipients. This commit adds an empty line after the comment so the cursor starts in an empty line and allows you to start editing either by clicking "i" or "o". 

There may be a further improvement to start the scratch buffer in insert mode.