### PR TITLE
Fix issues with GPGEdit{Recipients,Options}

### DIFF
--- a/autoload/gnupg.vim
+++ b/autoload/gnupg.vim
@@ -1,5 +1,5 @@
 " Name:    autoload/gnupg.vim
-" Last Change: 2020 Nov 09
+" Last Change: 2020 Nov 11
 " Maintainer:  James McCoy <jamessan@jamessan.com>
 " Original Author:  Markus Braun <markus.braun@krawel.de>
 " Summary: Vim plugin for transparent editing of gpg encrypted files.
@@ -685,7 +685,8 @@ function gnupg#edit_recipients()
     augroup GPGRecipients
       au! * <buffer>
       " add a autocommand to regenerate the recipients after a write
-      autocmd BufHidden,BufUnload,BufWriteCmd <buffer> call s:GPGFinishRecipientsBuffer()
+      autocmd BufHidden,BufWriteCmd <buffer> call s:GPGFinishRecipientsBuffer()
+      autocmd BufUnload <buffer> exe 'au! GPGRecipients * <buffer='. expand('<abuf>') .'>'
     augroup END
 
     " put some comments to the scratch buffer
@@ -861,7 +862,8 @@ function gnupg#edit_options()
     augroup GPGOptions
       au! * <buffer>
       " add a autocommand to regenerate the options after a write
-      autocmd BufHidden,BufUnload,BufWriteCmd <buffer> call s:GPGFinishOptionsBuffer()
+      autocmd BufHidden,BufWriteCmd <buffer> call s:GPGFinishOptionsBuffer()
+      autocmd BufUnload <buffer> exe 'au! GPGOptions * <buffer='. expand('<abuf>') .'>'
     augroup END
 
     " put some comments to the scratch buffer

--- a/autoload/gnupg.vim
+++ b/autoload/gnupg.vim
@@ -769,8 +769,14 @@ function s:GPGFinishRecipientsBuffer()
 
   " go to buffer before doing work
   if (bufnr("%") != expand("<abuf>"))
-    " switch to scratch buffer window
-    execute 'silent! ' . bufwinnr(expand("<afile>:p")) . "wincmd w"
+    let winnr = bufwinnr(expand('<afile>:p'))
+    if winnr >= 0
+      " switch to scratch buffer window
+      execute 'silent! ' . winnr . "wincmd w"
+    else
+      call s:GPGDebug(3, '<<<<<<<< Leaving s:GPGFinishRecipientsBuffer() early because buffer is not displayed')
+      return
+    endif
   endif
 
   " get the recipients from the scratch buffer
@@ -915,8 +921,14 @@ function s:GPGFinishOptionsBuffer()
 
   " go to buffer before doing work
   if (bufnr("%") != expand("<abuf>"))
-    " switch to scratch buffer window
-    execute 'silent! ' . bufwinnr(expand("<afile>:p")) . "wincmd w"
+    let winnr = bufwinnr(expand('<afile>:p'))
+    if winnr >= 0
+      " switch to scratch buffer window
+      execute 'silent! ' . winnr . "wincmd w"
+    else
+      call s:GPGDebug(3, '<<<<<<<< Leaving s:GPGFinishOptionsBuffer() early because buffer is not displayed')
+      return
+    endif
   endif
 
   " clear options and unknownOptions

--- a/plugin/gnupg.vim
+++ b/plugin/gnupg.vim
@@ -1,5 +1,5 @@
 " Name:    gnupg.vim
-" Last Change: 2020 Nov 09
+" Last Change: 2020 Nov 11
 " Maintainer:  James McCoy <jamessan@jamessan.com>
 " Original Author:  Markus Braun <markus.braun@krawel.de>
 " Summary: Vim plugin for transparent editing of gpg encrypted files.
@@ -15,7 +15,7 @@
 if (exists("g:loaded_gnupg") || &cp || exists("#GnuPG"))
   finish
 endif
-let g:loaded_gnupg = '2.7.0'
+let g:loaded_gnupg = '2.7.1-dev'
 
 " check for correct vim version {{{2
 if (v:version < 702)


### PR DESCRIPTION
* The "Finish" function shouldn't run during Vim shutdown, so change BufUnload to clear the autocommands.  The BufHidden autocommand has already performed the relevant "Finish" routine.
* Handle a -1 return from `bufwinnr()` and exit early from the Finish function, instead of parsing the wrong buffer.

Closes #104

Cc @leahneukirchen @ThomasAH